### PR TITLE
fix: flashbots bundle eligibility

### DIFF
--- a/src/platform/bundle.rs
+++ b/src/platform/bundle.rs
@@ -356,6 +356,10 @@ impl<P: Platform> FlashbotsBundle<P> {
 			return Eligibility::TemporarilyIneligible;
 		}
 
+		// assertions:
+		// - transaction count > 0
+		// - min_timestamp < timestamp < max_timestamp
+		// - block_number == number
 		Eligibility::Eligible
 	}
 }


### PR DESCRIPTION
Within `is_eligible` method of FlashbotsBundle:
- self.block_number is checked against parent block number. I believe checking against the current payload's number is better?
- Might be better to check `PermanentlyIneligible` first to prevent early returns of potential `TemporarilyIneligible` when the bundle should be considered as `PermanentlyIneligible`
- if max_timestamp > block_timestamp then `PermanentlyIneligible` is incorrectly returned. It should be when max_timestamp < block_timestamp
- Similarly, if min_timestamp < block_timestamp then `TemporarilyIneligible` is incorrectly returned. It should be when min_timestamp > block_timestamp

If this is correct, then the eligibility logic can be refactored in a `eligibility_at(timestamp: u64, number: u64)` and used in both `is_eligible` and `is_permanently_ineligible` methods.