### PR TITLE
fix: rename history_mut/const to staging/sealed

### DIFF
--- a/src/payload/checkpoint.rs
+++ b/src/payload/checkpoint.rs
@@ -193,7 +193,7 @@ impl<P: Platform> Checkpoint<P> {
 
 	/// Creates a new checkpoint on top of the current checkpoint that introduces
 	/// a barrier. This new checkpoint will be now considered the new beginning of
-	/// mutable history.
+	/// staging history.
 	#[must_use]
 	pub fn barrier(&self) -> Self {
 		Self::apply_with(self, Mutation::Barrier)
@@ -219,7 +219,7 @@ impl<P: Platform> Checkpoint<P> {
 
 	/// Creates a new checkpoint on top of the current checkpoint that introduces
 	/// a named barrier. This new checkpoint will be now considered the new
-	/// beginning of mutable history.
+	/// beginning of staging history.
 	#[must_use]
 	pub fn named_barrier(&self, name: impl Into<String>) -> Self {
 		Self {
@@ -282,7 +282,7 @@ enum Mutation<P: Platform> {
 	/// do not modify the commited state of the payload in process.
 	///
 	/// If there are multiple barriers in the history, the last one is considered
-	/// as the beginning of the mutable history.
+	/// as the beginning of the staging history.
 	///
 	/// The very first checkpoint in the history is always a barrier, as it
 	/// represents the baseline checkpoint that has no transactions in its

--- a/src/payload/ext/checkpoint.rs
+++ b/src/payload/ext/checkpoint.rs
@@ -57,10 +57,10 @@ pub trait CheckpointExt<P: Platform>: super::sealed::Sealed {
 	/// block payload we're building to the current checkpoint.
 	fn history(&self) -> Span<P>;
 
-	/// Returns a span that includes all mutable history of this checkpoint,
-	/// which is all preceeding checkpoints from the last barrier, or the entire
+	/// Returns a span that includes all staging history of this checkpoint,
+	/// which is all preceding checkpoints from the last barrier, or the entire
 	/// history if there is no barrier checkpoint.
-	fn history_mut(&self) -> Span<P> {
+	fn history_staging(&self) -> Span<P> {
 		let history = self.history();
 		let immutable_prefix = history
 			.iter()
@@ -69,11 +69,11 @@ pub trait CheckpointExt<P: Platform>: super::sealed::Sealed {
 		history.skip(immutable_prefix)
 	}
 
-	/// Returns a span that includes all checkpoints in the immutable history,
+	/// Returns a span that includes all checkpoints in the sealed history,
 	/// that is the history from the beginning of the block until the last
 	/// barrier included. If there are no barriers, the entire history is
 	/// returned.
-	fn history_const(&self) -> Span<P> {
+	fn history_sealed(&self) -> Span<P> {
 		let history = self.history();
 		let immutable_prefix = history
 			.iter()

--- a/src/steps/optimism.rs
+++ b/src/steps/optimism.rs
@@ -96,9 +96,9 @@ mod tests {
 		};
 
 		assert_eq!(payload.history().transactions().count(), 0);
-		assert_eq!(payload.history_const().len(), 1); // only baseline checkpoint
-		assert_eq!(payload.history_mut().len(), 1); // only last barrier
-		assert_eq!(payload.history_mut().transactions().count(), 0);
+		assert_eq!(payload.history_sealed().len(), 1); // only baseline checkpoint
+		assert_eq!(payload.history_staging().len(), 1); // only last barrier
+		assert_eq!(payload.history_staging().transactions().count(), 0);
 	}
 
 	#[tokio::test]
@@ -124,19 +124,19 @@ mod tests {
 		);
 
 		assert_eq!(
-			payload.history_const().len(),
+			payload.history_sealed().len(),
 			3,
-			"immutable history should have 3 checkpoints: baseline, sequencer tx \
-			 and last barrier"
+			"sealed history should have 3 checkpoints: baseline, sequencer tx and \
+			 last barrier"
 		);
 
 		assert_eq!(
-			payload.history_mut().len(),
+			payload.history_staging().len(),
 			1,
-			"mutable history should have 1 checkpoint: last barrier"
+			"staging history should have 1 checkpoint: last barrier"
 		);
 
-		let const_history = payload.history_const();
+		let const_history = payload.history_sealed();
 		let first_tx = const_history.transactions().next().unwrap();
 		assert!(first_tx.is_deposit(), "Sequencer tx should be a deposit");
 	}

--- a/src/steps/ordering/mod.rs
+++ b/src/steps/ordering/mod.rs
@@ -44,10 +44,10 @@ impl<P: Platform, S: OrderScore<P>> Step<P> for OrderBy<P, S> {
 		payload: Checkpoint<P>,
 		_ctx: StepContext<P>,
 	) -> ControlFlow<P> {
-		// create a span that contains all mutable checkpoints in the payload.
+		// create a span that contains all staged checkpoints in the payload.
 		// We're guaranteed that all checkpoints in this span are executables,
-		// because the mutable history begins after the last barrier checkpoint.
-		let history = payload.history_mut();
+		// because the staging history begins after the last barrier checkpoint.
+		let history = payload.history_staging();
 
 		// Find the correct order of orders in the payload.
 		let ordered = match SortedOrders::<P, S>::try_from(&history) {

--- a/src/steps/ordering/profit.rs
+++ b/src/steps/ordering/profit.rs
@@ -26,7 +26,7 @@ impl<P: Platform> OrderScore<P> for CoinbaseProfitScore<P> {
 	}
 }
 
-/// This step will sort the checkpoints in the mutable part of the payload by
+/// This step will sort the checkpoints in the staging part of the payload by
 /// the difference in the coinbase account balance before and after they are
 /// executed.
 pub type OrderByCoinbaseProfit<P: Platform> =

--- a/src/steps/ordering/tip.rs
+++ b/src/steps/ordering/tip.rs
@@ -20,7 +20,7 @@ impl<P: Platform> OrderScore<P> for PriorityFeeScore<P> {
 /// priority fee. During the sorting the transactions will preserve their
 /// sender, nonce dependencies.
 ///
-/// Sorting happens only for the mutable part of the payload, i.e. after
+/// Sorting happens only for the staging part of the payload, i.e. after
 /// the last barrier checkpoint. Anything prior to the last barrier
 /// checkpoint is considered immutable and will not be reordered.
 pub type OrderByPriorityFee<P: Platform> = OrderBy<P, PriorityFeeScore<P>>;

--- a/src/steps/revert.rs
+++ b/src/steps/revert.rs
@@ -64,9 +64,9 @@ impl<P: Platform> Step<P> for RemoveRevertedTransactions {
 			return ControlFlow::Ok(payload);
 		}
 
-		// we're working only with the mutable history of the payload,
+		// we're working only with the staging history of the payload,
 		// if a reverting transaction was already commited, we will not remove it.
-		let history = payload.history_mut();
+		let history = payload.history_staging();
 
 		// First identify a valid prefix of the payload history that does not
 		// contain any reverts we can remove. This will be the baseline checkpoint


### PR DESCRIPTION
Close #16

Rename Checkpoint's history parts to decouple it from rust mut/const:
- `history_const` -> `history_sealed` to express the immutable, finalized part of history
- `history_mut` -> `history_staging` to express the mutable, active, in-progress part of history