### PR TITLE
Fix job accumulation issue

### DIFF
--- a/src/pipelines/job.rs
+++ b/src/pipelines/job.rs
@@ -69,6 +69,8 @@ where
 
 		// Job should complete within deadline (12s) even if GetPayload is never
 		// called. This prevents job accumulation.
+		// TODO: when FCU update avalanche is fixed we could replace
+		// builder.deadline with payload.attributes.timeout
 		let deadline =
 			Box::pin(tokio::time::sleep(service.node_config().builder.deadline));
 


### PR DESCRIPTION
We have an issue with job accumulation or non-active builders.
To fix this we could respect builder.deadline param from cli and terminate stale jobs.