### PR TITLE
make step setup fn async

### DIFF
--- a/src/pipelines/service.rs
+++ b/src/pipelines/service.rs
@@ -79,7 +79,7 @@ where
 			navi.instance().init_metrics(&metrics_scope);
 
 			let init_ctx = InitContext::new(Arc::clone(&provider), metrics_scope);
-			navi.instance().setup(init_ctx)?;
+			navi.instance().setup(init_ctx).await?;
 		}
 
 		let (service, builder) = PayloadBuilderService::new(

--- a/src/pipelines/step/mod.rs
+++ b/src/pipelines/step/mod.rs
@@ -78,8 +78,11 @@ pub trait Step<P: Platform>: Send + Sync + 'static {
 
 	/// Optional setup function called exactly once when a pipeline is
 	/// instantiated as a payload builder service, before any payload jobs run.
-	fn setup(&mut self, _: InitContext<P>) -> Result<(), PayloadBuilderError> {
-		Ok(())
+	fn setup(
+		&mut self,
+		_: InitContext<P>,
+	) -> impl Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
+		async { Ok(()) }
 	}
 }
 

--- a/src/pool/step.rs
+++ b/src/pool/step.rs
@@ -135,7 +135,10 @@ impl<P: Platform> Step<P> for AppendOrders<P> {
 	/// instantiated into a payload builder service.
 	///
 	/// Initializes metrics for this step.
-	fn setup(&mut self, init: InitContext<P>) -> Result<(), PayloadBuilderError> {
+	async fn setup(
+		&mut self,
+		init: InitContext<P>,
+	) -> Result<(), PayloadBuilderError> {
 		self.metrics = Metrics::with_scope(init.metrics_scope());
 		Ok(())
 	}

--- a/src/steps/revert.rs
+++ b/src/steps/revert.rs
@@ -26,7 +26,10 @@ impl<P: Platform> Step<P> for RemoveRevertedTransactions {
 	/// instantiated into a payload builder service.
 	///
 	/// Initializes metrics for this step.
-	fn setup(&mut self, init: InitContext<P>) -> Result<(), PayloadBuilderError> {
+	async fn setup(
+		&mut self,
+		init: InitContext<P>,
+	) -> Result<(), PayloadBuilderError> {
 		self.metrics = Metrics::with_scope(init.metrics_scope());
 		Ok(())
 	}


### PR DESCRIPTION
Sometimes we need to call async code in the setup function for a step.

In particular, getting an attestation is an async operation since we make an http request to get it -- so we'll need this for flashtestations.