### PR TITLE
feat: Step object-safe

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,6 +158,7 @@ tracing-subscriber = { version = "0.3", features = [
     "env-filter",
     "json",
 ], optional = true }
+async-trait = "0.1.89"
 
 [target.'cfg(unix)'.dependencies]
 tikv-jemallocator = { version = "0.6", optional = true }

--- a/src/pipelines/events.rs
+++ b/src/pipelines/events.rs
@@ -113,6 +113,7 @@ mod tests {
 	struct UInt32Event(u32);
 
 	struct StepEmittingOneTypeOfEvent;
+	#[async_trait::async_trait]
 	impl<P: Platform> Step<P> for StepEmittingOneTypeOfEvent {
 		async fn before_job(
 			self: Arc<Self>,
@@ -142,6 +143,7 @@ mod tests {
 	}
 
 	struct StepEmittingTwoTypesOfEvents;
+	#[async_trait::async_trait]
 	impl<P: Platform> Step<P> for StepEmittingTwoTypesOfEvents {
 		async fn before_job(
 			self: Arc<Self>,

--- a/src/pipelines/limits.rs
+++ b/src/pipelines/limits.rs
@@ -353,6 +353,7 @@ mod tests {
 		}
 	}
 
+	#[async_trait::async_trait]
 	impl<P: Platform> Step<P> for TestStep {
 		async fn step(
 			self: Arc<Self>,

--- a/src/pipelines/step/instance.rs
+++ b/src/pipelines/step/instance.rs
@@ -140,7 +140,7 @@ impl<P: Platform> StepInstance<P> {
 						&mut *mut_ptr
 					};
 
-					step.setup(ctx).boxed()
+					step.setup(ctx)
 				},
 			) as WrappedSetupFn<P>,
 			name: Name::new::<S, P>(),

--- a/src/pipelines/step/mod.rs
+++ b/src/pipelines/step/mod.rs
@@ -1,6 +1,6 @@
 use {
 	crate::{prelude::*, reth},
-	core::{fmt::Debug, future::Future, marker::PhantomData},
+	core::{fmt::Debug, marker::PhantomData},
 	reth::providers::StateProviderFactory,
 	std::sync::Arc,
 };
@@ -37,17 +37,18 @@ pub use {context::StepContext, reth::payload::builder::PayloadBuilderError};
 /// There may be multiple instances of the same step in a pipeline.
 ///
 /// A step instance is guaranteed to not be called concurrently by the runtime.
+#[async_trait::async_trait]
 pub trait Step<P: Platform>: Send + Sync + 'static {
 	/// Gets called every time this step is executed in the pipeline.
 	///
 	/// As an input it takes the payload that has been built so far and outputs
 	/// a new payload that will be used in the next step of the pipeline, or a
 	/// failure that will terminate the pipeline execution.
-	fn step(
+	async fn step(
 		self: Arc<Self>,
 		payload: Checkpoint<P>,
 		ctx: StepContext<P>,
-	) -> impl Future<Output = ControlFlow<P>> + Send + Sync;
+	) -> ControlFlow<P>;
 
 	/// This function is called once per new payload job before any steps are
 	/// executed. It can be used by steps to perform any optional initialization
@@ -55,11 +56,11 @@ pub trait Step<P: Platform>: Send + Sync + 'static {
 	///
 	/// If this function returns an error, the pipeline execution will be
 	/// terminated immediately and no steps will be executed.
-	fn before_job(
+	async fn before_job(
 		self: Arc<Self>,
 		_: StepContext<P>,
-	) -> impl Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
-		async { Ok(()) }
+	) -> Result<(), PayloadBuilderError> {
+		Ok(())
 	}
 
 	/// This function is called once after all steps in the pipeline have been
@@ -68,21 +69,21 @@ pub trait Step<P: Platform>: Send + Sync + 'static {
 	///
 	/// A failure in this function will invalidate the whole payload job
 	/// and will not produce a valid payload.
-	fn after_job(
+	async fn after_job(
 		self: Arc<Self>,
 		_: StepContext<P>,
 		_: Arc<Result<types::BuiltPayload<P>, PayloadBuilderError>>,
-	) -> impl Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
-		async { Ok(()) }
+	) -> Result<(), PayloadBuilderError> {
+		Ok(())
 	}
 
 	/// Optional setup function called exactly once when a pipeline is
 	/// instantiated as a payload builder service, before any payload jobs run.
-	fn setup(
+	async fn setup(
 		&mut self,
 		_: InitContext<P>,
-	) -> impl Future<Output = Result<(), PayloadBuilderError>> + Send + Sync {
-		async { Ok(()) }
+	) -> Result<(), PayloadBuilderError> {
+		Ok(())
 	}
 }
 

--- a/src/pool/step.rs
+++ b/src/pool/step.rs
@@ -130,6 +130,7 @@ impl<P: Platform> AppendOrders<P> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for AppendOrders<P> {
 	// Called exactly once by the runtime when the enclosing pipeline is
 	/// instantiated into a payload builder service.

--- a/src/steps/builder.rs
+++ b/src/steps/builder.rs
@@ -74,6 +74,7 @@ impl<P: PlatformWithRpcTypes> BuilderEpilogue<P> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<P: PlatformWithRpcTypes> Step<P> for BuilderEpilogue<P> {
 	async fn step(
 		self: Arc<Self>,

--- a/src/steps/optimism.rs
+++ b/src/steps/optimism.rs
@@ -5,6 +5,7 @@ use {crate::prelude::*, std::sync::Arc};
 /// It requires that the payload has no existing transactions in it as the
 /// sequencer expects its transactions to be at the top of the block.
 pub struct OptimismPrologue;
+#[async_trait::async_trait]
 impl<P> Step<P> for OptimismPrologue
 where
 	P: traits::PlatformExecBounds<Optimism>,
@@ -77,6 +78,7 @@ mod tests {
 	};
 
 	struct NoOpStep;
+	#[async_trait::async_trait]
 	impl Step<Optimism> for NoOpStep {
 		async fn step(
 			self: Arc<Self>,

--- a/src/steps/ordering/mod.rs
+++ b/src/steps/ordering/mod.rs
@@ -38,6 +38,7 @@ pub trait OrderScore<P: Platform>:
 /// checkpoint is considered immutable and will not be reordered.
 #[derive(Debug, Clone, Default)]
 pub struct OrderBy<P: Platform, S: OrderScore<P>>(PhantomData<(P, S)>);
+#[async_trait::async_trait]
 impl<P: Platform, S: OrderScore<P>> Step<P> for OrderBy<P, S> {
 	async fn step(
 		self: Arc<Self>,

--- a/src/steps/revert.rs
+++ b/src/steps/revert.rs
@@ -21,6 +21,7 @@ pub struct RemoveRevertedTransactions {
 	per_job: PerJobCounters,
 }
 
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for RemoveRevertedTransactions {
 	/// Called exactly once by the runtime when the enclosing pipeline is
 	/// instantiated into a payload builder service.

--- a/src/steps/utils.rs
+++ b/src/steps/utils.rs
@@ -1,6 +1,7 @@
 use crate::prelude::*;
 
 pub struct BreakAfterDeadline;
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for BreakAfterDeadline {
 	async fn step(
 		self: std::sync::Arc<Self>,

--- a/src/test_utils/step.rs
+++ b/src/test_utils/step.rs
@@ -17,6 +17,7 @@ macro_rules! fake_step {
 	($name:ident) => {
 		#[derive(Debug, Default, Clone)]
 		pub(super) struct $name;
+		#[async_trait::async_trait]
 		impl<P: $crate::prelude::Platform> $crate::prelude::Step<P> for $name {
 			async fn step(
 				self: std::sync::Arc<Self>,
@@ -31,6 +32,7 @@ macro_rules! fake_step {
 	($name:ident, noop_ok) => {
 		#[derive(Debug, Default, Clone)]
 		pub struct $name;
+		#[async_trait::async_trait]
 		impl<P: $crate::prelude::Platform> $crate::prelude::Step<P> for $name {
 			async fn step(
 				self: std::sync::Arc<Self>,
@@ -45,6 +47,7 @@ macro_rules! fake_step {
 	($name:ident, noop_break) => {
 		#[derive(Debug, Default, Clone)]
 		pub struct $name;
+		#[async_trait::async_trait]
 		impl<P: $crate::prelude::Platform> $crate::prelude::Step<P> for $name {
 			async fn step(
 				self: std::sync::Arc<Self>,
@@ -60,6 +63,7 @@ macro_rules! fake_step {
 		#[allow(dead_code)]
 		#[derive(Debug, Clone)]
 		pub(super) struct $name($state);
+		#[async_trait::async_trait]
 		impl<P: $crate::prelude::Platform> $crate::prelude::Step<P> for $name {
 			async fn step(
 				self: std::sync::Arc<Self>,
@@ -76,6 +80,7 @@ pub(crate) use fake_step;
 
 /// A step that always return `ControlFlow::Break` with the input payload.
 pub struct AlwaysBreakStep;
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for AlwaysBreakStep {
 	async fn step(
 		self: Arc<Self>,
@@ -88,6 +93,7 @@ impl<P: Platform> Step<P> for AlwaysBreakStep {
 
 /// A step that always returns `ControlFlow::Ok` with the input payload.
 pub struct AlwaysOkStep;
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for AlwaysOkStep {
 	async fn step(
 		self: Arc<Self>,
@@ -101,6 +107,7 @@ impl<P: Platform> Step<P> for AlwaysOkStep {
 /// A step that always returns `ControlFlow::Fail` with
 /// `PayloadBuilderError::Other`.
 pub struct AlwaysFailStep;
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for AlwaysFailStep {
 	async fn step(
 		self: Arc<Self>,
@@ -308,6 +315,7 @@ impl<P: PlatformWithRpcTypes> PopulatePayload<P> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<P: PlatformWithRpcTypes> Step<P> for PopulatePayload<P> {
 	async fn step(
 		self: Arc<Self>,
@@ -343,6 +351,7 @@ impl<P: Platform> RecordOk<P> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for RecordOk<P> {
 	async fn step(
 		self: Arc<Self>,
@@ -378,6 +387,7 @@ impl<P: Platform> RecordBreakAndFail<P> {
 	}
 }
 
+#[async_trait::async_trait]
 impl<P: Platform> Step<P> for RecordBreakAndFail<P> {
 	async fn step(
 		self: Arc<Self>,


### PR DESCRIPTION
If we want to have composite steps (collection of any kind of steps), we need to make `Step` object-safe.

Using `async-trait` helps reduce changes and because it boxes returned futures it makes `Step` object-safe.

This is a breaking change.