### PR TITLE
feat: sugar for conditionally adding steps

### DIFF
--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -81,6 +81,12 @@ impl<P: Platform> Pipeline<P> {
 		this
 	}
 
+	/// Conditionally add a prologue
+	#[must_use]
+	pub fn with_prologue_if(self, cond: bool, step: impl Step<P>) -> Self {
+		if cond { self.with_prologue(step) } else { self }
+	}
+
 	/// A step that happens as the last step of the block after the whole payload
 	/// has been built. Can be called multiple times to add multiple epilogue
 	/// steps.
@@ -89,6 +95,12 @@ impl<P: Platform> Pipeline<P> {
 		let mut this = self;
 		this.epilogue.push(Arc::new(StepInstance::new(step)));
 		this
+	}
+
+	/// Conditionally add an epilogue
+	#[must_use]
+	pub fn with_epilogue_if(self, cond: bool, step: impl Step<P>) -> Self {
+		if cond { self.with_epilogue(step) } else { self }
 	}
 
 	/// A step that runs with an input that is the result of the previous step.
@@ -101,6 +113,12 @@ impl<P: Platform> Pipeline<P> {
 			.steps
 			.push(StepOrPipeline::Step(Arc::new(StepInstance::new(step))));
 		this
+	}
+
+	/// Conditionally add a step
+	#[must_use]
+	pub fn with_step_if(self, cond: bool, step: impl Step<P>) -> Self {
+		if cond { self.with_step(step) } else { self }
 	}
 
 	/// Adds a nested pipeline to the current pipeline.


### PR DESCRIPTION
We have a lot of steps in unichain-builder that we only want to add if a flag is enabled. This is just some syntactic sugar so we don't need to define an intermediate named variable to conditionally add steps and so it's easier to see all the steps in a pipeline.

For example, the code in https://github.com/flashbots/unichain-builder/blob/main/src/main.rs#L99-L152 would become this:

```
let pipeline = Pipeline::<Flashblocks>::named("top")
	.with_step(OptimismPrologue)
	.with_step_if(
		cli_args.flashtestations.flashtestations_enabled
			&& cli_args.builder_signer.is_some(),
		FlashtestationsPrologue::try_new(
			cli_args.flashtestations.clone(),
			cli_args.builder_signer.clone().unwrap(),
		)?,
	)
	.with_pipeline(
		Loop,
		Pipeline::named("n_flashblocks")
			.with_pipeline(
				Once,
				Pipeline::named("single_flashblock")
					.with_pipeline(
						Loop,
						Pipeline::named("flashblock_steps")
							.with_step(AppendOrders::from_pool(pool).with_ok_on_limit())
							.with_step(OrderByPriorityFee::default())
							.with_step_if(
								cli_args.revert_protection,
								RemoveRevertedTransactions::default(),
							)
							.with_step(BreakAfterDeadline)
							.with_epilogue_if(
								cli_args.builder_signer.is_some(),
								BuilderEpilogue::with_signer(
									cli_args.builder_signer.clone().unwrap().clone().into(),
								)
								.with_message(|block| {
									format!("Block Number: {}", block.number())
								}),
							)
							.with_epilogue(PublishFlashblock::new(
								ws.clone(),
								flashblock_number.clone(),
								cli_args.flashblocks_args.calculate_state_root,
							))
							.with_limits(FlashblockLimits::new(
								interval,
								flashblock_number.clone(),
							)),
					)
					.with_step(BreakAfterDeadline),
			)
			.with_step(BreakAfterMaxFlashblocks::new(flashblock_number)),
	)
	.with_limits(Scaled::default().deadline(total_building_time));
```