### PR TITLE
feat: add ordering by destination

### DIFF
--- a/src/steps/ordering/destination.rs
+++ b/src/steps/ordering/destination.rs
@@ -39,14 +39,18 @@ impl<P: Platform> OrderScore<P> for DestinationAndPriorityFeeScore<P> {
 	// two-tier priority system which we want: Transactions going to the
 	// destination address are always prioritized over transactions that aren't.
 	// Within each tier, they're ordered by effective tip.
-	fn score(&self, checkpoint: &Checkpoint<P>) -> Result<Self::Score, Self::Error> {
+	fn score(
+		&self,
+		checkpoint: &Checkpoint<P>,
+	) -> Result<Self::Score, Self::Error> {
 		let all_destination = checkpoint
 			.transactions()
 			.iter()
 			.all(|tx| tx.to() == Some(self.destination_address));
 		let tip_sum = CheckpointExt::effective_tip_per_gas(checkpoint);
-		Ok((all_destination as u8, tip_sum))
+		Ok((u8::from(all_destination), tip_sum))
 	}
 }
 
-pub type OrderByDestinationAndPriorityFee<P> = OrderBy<P, DestinationAndPriorityFeeScore<P>>;
+pub type OrderByDestinationAndPriorityFee<P> =
+	OrderBy<P, DestinationAndPriorityFeeScore<P>>;

--- a/src/steps/ordering/mod.rs
+++ b/src/steps/ordering/mod.rs
@@ -16,7 +16,10 @@ mod profit;
 mod tip;
 
 pub use {
-	destination::{DestinationAndPriorityFeeScore, OrderByDestinationAndPriorityFee},
+	destination::{
+		DestinationAndPriorityFeeScore,
+		OrderByDestinationAndPriorityFee,
+	},
 	profit::OrderByCoinbaseProfit,
 	tip::OrderByPriorityFee,
 };
@@ -30,7 +33,10 @@ pub trait OrderScore<P: Platform>:
 	type Score: Clone + Ord + Eq + core::hash::Hash;
 	type Error: core::error::Error + Send + Sync + 'static;
 
-	fn score(&self, checkpoint: &Checkpoint<P>) -> Result<Self::Score, Self::Error>;
+	fn score(
+		&self,
+		checkpoint: &Checkpoint<P>,
+	) -> Result<Self::Score, Self::Error>;
 }
 
 /// A generic implementation of a step that will order checkpoints based on a
@@ -76,7 +82,8 @@ impl<P: Platform, S: OrderScore<P>> Step<P> for OrderBy<P, S> {
 		let history = payload.history_staging();
 
 		// Find the correct order of orders in the payload.
-		let ordered = match SortedOrders::<P, S>::try_from((&history, &self.scorer)) {
+		let ordered = match SortedOrders::<P, S>::try_from((&history, &self.scorer))
+		{
 			Ok(ordered) => ordered.into_iter(),
 			// when the step started running, the payload had no nonce conflicts and
 			// all orders were able to construct valid checkpoints. After reordering,
@@ -146,7 +153,9 @@ impl<'a, P: Platform, S: OrderScore<P>> TryFrom<(&'a Span<P>, &'a S)>
 {
 	type Error = S::Error;
 
-	fn try_from((span, scorer): (&'a Span<P>, &'a S)) -> Result<Self, Self::Error> {
+	fn try_from(
+		(span, scorer): (&'a Span<P>, &'a S),
+	) -> Result<Self, Self::Error> {
 		let executables = span.iter().filter(|checkpoint| !checkpoint.is_barrier());
 		let all_orders: HashMap<B256, &'a Checkpoint<P>> = executables
 			.map(|checkpoint| (checkpoint.hash().unwrap(), checkpoint))

--- a/src/steps/ordering/profit.rs
+++ b/src/steps/ordering/profit.rs
@@ -13,7 +13,10 @@ impl<P: Platform> OrderScore<P> for CoinbaseProfitScore<P> {
 	type Error = ProviderError;
 	type Score = U256;
 
-	fn score(&self, checkpoint: &Checkpoint<P>) -> Result<Self::Score, Self::Error> {
+	fn score(
+		&self,
+		checkpoint: &Checkpoint<P>,
+	) -> Result<Self::Score, Self::Error> {
 		let fee_recipient = checkpoint.block().coinbase();
 		let current_balance = checkpoint.balance_of(fee_recipient)?;
 

--- a/src/steps/ordering/tip.rs
+++ b/src/steps/ordering/tip.rs
@@ -11,7 +11,10 @@ impl<P: Platform> OrderScore<P> for PriorityFeeScore<P> {
 	type Error = Infallible;
 	type Score = u128;
 
-	fn score(&self, checkpoint: &Checkpoint<P>) -> Result<Self::Score, Self::Error> {
+	fn score(
+		&self,
+		checkpoint: &Checkpoint<P>,
+	) -> Result<Self::Score, Self::Error> {
 		Ok(checkpoint.effective_tip_per_gas())
 	}
 }


### PR DESCRIPTION
This PR implements `OrderByDestinationAndPriorityFee`, and ordering that prioritizes transactions going to a provided destination, followed by transactions that aren't going to the given destination. Inside each of these groups, transactions are ordered by priority fee.

To implement this, we also had to modify `OrderBy` to store a `OrderScore` field, which would allow `DestinationAndPriorityFeeScore`'s `score()` being able to access its `destination_address` field.  

This enables top-of-block oracle updates for updates sent to the [Global Storage](https://github.com/flashbots/global-storage-smart-contract) smart contract.

