### PR TITLE
revert: multiple epilogues

### DIFF
--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -40,7 +40,7 @@ pub enum Behavior {
 }
 
 pub struct Pipeline<P: Platform> {
-	epilogue: Vec<Arc<StepInstance<P>>>,
+	epilogue: Option<Arc<StepInstance<P>>>,
 	prologue: Option<Arc<StepInstance<P>>>,
 	steps: Vec<StepOrPipeline<P>>,
 	limits: Option<Arc<dyn ScopedLimits<P>>>,
@@ -53,7 +53,7 @@ impl<P: Platform> Default for Pipeline<P> {
 	#[track_caller]
 	fn default() -> Self {
 		Self {
-			epilogue: Vec::new(),
+			epilogue: None,
 			prologue: None,
 			steps: Vec::new(),
 			limits: None,
@@ -88,12 +88,11 @@ impl<P: Platform> Pipeline<P> {
 	}
 
 	/// A step that happens as the last step of the block after the whole payload
-	/// has been built. Can be called multiple times to add multiple epilogue
-	/// steps.
+	/// has been built.
 	#[must_use]
 	pub fn with_epilogue(self, step: impl Step<P>) -> Self {
 		let mut this = self;
-		this.epilogue.push(Arc::new(StepInstance::new(step)));
+		this.epilogue = Some(Arc::new(StepInstance::new(step)));
 		this
 	}
 
@@ -170,7 +169,7 @@ impl<P: Platform> Pipeline<P> {
 impl<P: Platform> Pipeline<P> {
 	/// Returns true if the pipeline has no steps, prologue or epilogue.
 	pub fn is_empty(&self) -> bool {
-		self.prologue.is_none() && self.epilogue.is_empty() && self.steps.is_empty()
+		self.prologue.is_none() && self.epilogue.is_none() && self.steps.is_empty()
 	}
 
 	/// An optional name of the pipeline.
@@ -195,8 +194,8 @@ impl<P: Platform> Pipeline<P> {
 		self.prologue.as_ref()
 	}
 
-	pub(crate) fn epilogue(&self) -> &[Arc<StepInstance<P>>] {
-		&self.epilogue
+	pub(crate) fn epilogue(&self) -> Option<&Arc<StepInstance<P>>> {
+		self.epilogue.as_ref()
 	}
 
 	pub(crate) fn steps(&self) -> &[StepOrPipeline<P>] {
@@ -334,7 +333,7 @@ impl<P: Platform> core::fmt::Debug for Pipeline<P> {
 		f.debug_struct("Pipeline")
 			.field("name", &self.name())
 			.field("prologue", &self.prologue.as_ref().map(|p| p.name()))
-			.field("epilogue", &self.epilogue)
+			.field("epilogue", &self.epilogue.as_ref().map(|p| p.name()))
 			.field("steps", &self.steps)
 			.field("limits", &self.limits.is_some())
 			.finish_non_exhaustive()


### PR DESCRIPTION
This is no longer useful with combinator steps (especially Chain).
We can simplify pipeline navigation.