### PR TITLE
feat: platform-specific Limits extensions

### DIFF
--- a/examples/custom-bundle-type.rs
+++ b/examples/custom-bundle-type.rs
@@ -32,6 +32,7 @@ impl Platform for CustomPlatform {
 	type Bundle = CustomBundleType;
 	type DefaultLimits = types::DefaultLimits<Optimism>;
 	type EvmConfig = types::EvmConfig<Optimism>;
+	type ExtraLimits = types::ExtraLimits<Optimism>;
 	type NodeTypes = types::NodeTypes<Optimism>;
 	type PooledTransaction = types::PooledTransaction<Optimism>;
 

--- a/src/pipelines/exec/scope.rs
+++ b/src/pipelines/exec/scope.rs
@@ -82,7 +82,7 @@ impl<P: Platform> RootScope<P> {
 	}
 
 	/// Given a path to a step in the pipeline, returns its current limits.
-	pub(crate) fn limits_of(&self, step_path: &StepPath) -> Option<Limits> {
+	pub(crate) fn limits_of(&self, step_path: &StepPath) -> Option<Limits<P>> {
 		self
 			.root
 			.read()
@@ -169,7 +169,7 @@ fn scope_of(step: &StepPath) -> StepPath {
 /// that contain it. When a scope is active, then all its parent scopes are
 /// active as well.
 pub(crate) struct Scope<P: Platform> {
-	limits: Limits,
+	limits: Limits<P>,
 	metrics: Metrics,
 	limits_factory: Option<Arc<dyn ScopedLimits<P>>>,
 	entered_at: Option<Instant>,
@@ -197,7 +197,7 @@ impl<P: Platform> Scope<P> {
 	}
 
 	/// Returns the payload limits for steps running within the current scope.
-	pub(crate) const fn limits(&self) -> &Limits {
+	pub(crate) const fn limits(&self) -> &Limits<P> {
 		&self.limits
 	}
 }
@@ -240,7 +240,7 @@ impl<P: Platform> Scope<P> {
 		}
 	}
 
-	fn enter(&mut self, checkpoint: &Checkpoint<P>, enclosing: &Limits) {
+	fn enter(&mut self, checkpoint: &Checkpoint<P>, enclosing: &Limits<P>) {
 		assert!(!self.is_active(), "Scope is already active");
 
 		// refresh limits of this scope
@@ -308,7 +308,7 @@ impl<P: Platform> Scope<P> {
 		checkpoint: &Checkpoint<P>,
 		path: &StepPath,
 		root_name: &str,
-		enclosing: &Limits,
+		enclosing: &Limits<P>,
 	) -> Self {
 		let limits_factory = local.limits().cloned();
 		let scope_limits = limits_factory

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -409,12 +409,20 @@ pub mod traits {
 	}
 
 	pub trait PlatformExecBounds<P: Platform>:
-		Platform<NodeTypes = types::NodeTypes<P>, EvmConfig = types::EvmConfig<P>>
+		Platform<
+			NodeTypes = types::NodeTypes<P>,
+			EvmConfig = types::EvmConfig<P>,
+			ExtraLimits = types::ExtraLimits<P>,
+		>
 	{
 	}
 
 	impl<T, P: Platform> PlatformExecBounds<T> for P where
-		T: Platform<NodeTypes = types::NodeTypes<P>, EvmConfig = types::EvmConfig<P>>
+		T: Platform<
+				NodeTypes = types::NodeTypes<P>,
+				EvmConfig = types::EvmConfig<P>,
+				ExtraLimits = types::ExtraLimits<P>,
+			>
 	{
 	}
 }

--- a/src/pipelines/step/context.rs
+++ b/src/pipelines/step/context.rs
@@ -16,7 +16,7 @@ use {
 #[derive(Debug, Clone)]
 pub struct StepContext<P: Platform> {
 	block: BlockContext<P>,
-	limits: Limits,
+	limits: Limits<P>,
 	events_bus: Arc<EventsBus<P>>,
 	started_at: Option<Instant>,
 }
@@ -25,7 +25,7 @@ impl<P: Platform> StepContext<P> {
 	pub(crate) fn new(
 		block: &BlockContext<P>,
 		step: &StepNavigator<P>,
-		limits: Limits,
+		limits: Limits<P>,
 		in_scope_since: Option<Instant>,
 	) -> Self {
 		let block = block.clone();
@@ -60,7 +60,7 @@ impl<P: Platform> StepContext<P> {
 	}
 
 	/// Payload limits for the scope of the step.
-	pub const fn limits(&self) -> &Limits {
+	pub const fn limits(&self) -> &Limits<P> {
 		&self.limits
 	}
 

--- a/src/pipelines/tests/syntax.rs
+++ b/src/pipelines/tests/syntax.rs
@@ -104,7 +104,7 @@ fn flashblocks_example_closure() {
 	#[derive(Debug)]
 	struct FlashblockLimits(FlashblocksConfig);
 	impl<P: Platform> ScopedLimits<P> for FlashblockLimits {
-		fn create(&self, _: &Checkpoint<P>, _: &Limits) -> Limits {
+		fn create(&self, _: &Checkpoint<P>, _: &Limits<P>) -> Limits<P> {
 			unimplemented!()
 		}
 	}

--- a/src/platform/ethereum/limits.rs
+++ b/src/platform/ethereum/limits.rs
@@ -23,7 +23,7 @@ impl EthereumDefaultLimits {
 }
 
 impl PlatformLimits<Ethereum> for EthereumDefaultLimits {
-	fn create(&self, block: &BlockContext<Ethereum>) -> Limits {
+	fn create(&self, block: &BlockContext<Ethereum>) -> Limits<Ethereum> {
 		let timestamp = block.attributes().timestamp();
 		let parent_gas_limit = block.parent().gas_limit();
 		let gas_limit = self.0.gas_limit(parent_gas_limit);

--- a/src/platform/ethereum/mod.rs
+++ b/src/platform/ethereum/mod.rs
@@ -69,6 +69,7 @@ impl Platform for Ethereum {
 	type Bundle = FlashbotsBundle<Self>;
 	type DefaultLimits = EthereumDefaultLimits;
 	type EvmConfig = EthEvmConfig;
+	type ExtraLimits = ();
 	type NodeTypes = EthereumNode;
 	type PooledTransaction = EthPooledTransaction;
 

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -31,7 +31,7 @@ mod optimism;
 #[cfg(feature = "optimism")]
 pub use optimism::*;
 
-/// This type abstracts the platform specific types of the underlying node that
+/// This type abstracts the platform-specific types of the underlying node that
 /// is building block payloads.
 ///
 /// The payload builder API is agnostic to the underlying payload types, header
@@ -84,6 +84,11 @@ pub trait Platform:
 	/// If no limits are set on a pipeline explicitly, a default instance of this
 	/// type will be used automatically.
 	type DefaultLimits: PlatformLimits<Self>;
+
+	/// Type that can provide extra limits for the payload building process.
+	/// This type is used to provide platform-specific limits that are not
+	/// covered by the default `Limits` type.
+	type ExtraLimits: LimitExtension;
 
 	/// Instantiate the EVM configuration for the platform with a given chain
 	/// specification.

--- a/src/platform/optimism/limits.rs
+++ b/src/platform/optimism/limits.rs
@@ -16,6 +16,26 @@ use {
 #[derive(Debug, Clone, Default)]
 pub struct OptimismDefaultLimits;
 
+#[allow(clippy::struct_field_names)]
+#[derive(Default, Debug, Clone, Copy)]
+pub struct OpLimitsExt {
+	pub max_tx_da: Option<u64>,
+	pub max_block_da: Option<u64>,
+	pub max_block_da_footprint: Option<u64>,
+}
+
+impl LimitExtension for OpLimitsExt {
+	fn clamp(&self, other: &Self) -> Self {
+		Self {
+			max_tx_da: self.max_tx_da.min(other.max_tx_da),
+			max_block_da: self.max_block_da.min(other.max_block_da),
+			max_block_da_footprint: self
+				.max_block_da_footprint
+				.min(other.max_block_da_footprint),
+		}
+	}
+}
+
 impl<P> PlatformLimits<P> for OptimismDefaultLimits
 where
 	P: Platform<
@@ -28,7 +48,7 @@ where
 		>,
 	>,
 {
-	fn create(&self, block: &BlockContext<P>) -> Limits {
+	fn create(&self, block: &BlockContext<P>) -> Limits<P> {
 		let mut limits = Limits::gas_limit(
 			block
 				.attributes()

--- a/src/platform/optimism/mod.rs
+++ b/src/platform/optimism/mod.rs
@@ -1,10 +1,11 @@
 use {
-	crate::{alloy, prelude::*, reth},
+	crate::{alloy, platform, prelude::*, reth},
 	alloy::{
 		eips::Encodable2718,
 		optimism::consensus::OpPooledTransaction as AlloyPoolTx,
 		primitives::Bytes,
 	},
+	platform::optimism::limits::OpLimitsExt,
 	reth::{
 		api::NodeTypes,
 		chainspec::EthChainSpec,
@@ -32,6 +33,7 @@ impl Platform for Optimism {
 	type Bundle = FlashbotsBundle<Self>;
 	type DefaultLimits = OptimismDefaultLimits;
 	type EvmConfig = OpEvmConfig;
+	type ExtraLimits = OpLimitsExt;
 	type NodeTypes = OpNode;
 	type PooledTransaction = OpPooledTransaction;
 

--- a/src/platform/types.rs
+++ b/src/platform/types.rs
@@ -100,6 +100,9 @@ pub type EvmHaltReason<P: Platform> =
 /// process.
 pub type DefaultLimits<P: Platform> = P::DefaultLimits;
 
+/// Extracts the type that can provide additional limits.
+pub type ExtraLimits<P: Platform> = P::ExtraLimits;
+
 /// The result of executing a transaction in the EVM.
 pub type TransactionExecutionResult<P: Platform> =
 	ExecutionResult<EvmHaltReason<P>>;

--- a/src/pool/step.rs
+++ b/src/pool/step.rs
@@ -251,7 +251,7 @@ impl<'a, P: Platform> Run<'a, P> {
 		}
 	}
 
-	const fn limits(&self) -> &Limits {
+	const fn limits(&self) -> &Limits<P> {
 		self.ctx.limits()
 	}
 

--- a/src/steps/builder.rs
+++ b/src/steps/builder.rs
@@ -134,7 +134,11 @@ struct LimitsMinusEpilogue<P: Platform> {
 }
 
 impl<P: Platform> ScopedLimits<P> for LimitsMinusEpilogue<P> {
-	fn create(&self, payload: &Checkpoint<P>, enclosing: &Limits) -> Limits {
+	fn create(
+		&self,
+		payload: &Checkpoint<P>,
+		enclosing: &Limits<P>,
+	) -> Limits<P> {
 		// calculate the gas usage for the epilogue transaction
 		let message = (self.message_fn)(payload.block());
 		let gas_estimate = estimate_gas_for_tx(message.as_bytes());

--- a/src/test_utils/step.rs
+++ b/src/test_utils/step.rs
@@ -198,7 +198,7 @@ impl<P: PlatformWithRpcTypes + TestNodeFactory<P>> OneStep<P> {
 	}
 
 	#[must_use]
-	pub fn with_limits(mut self, limits: Limits) -> Self {
+	pub fn with_limits(mut self, limits: Limits<P>) -> Self {
 		self.pipeline = self.pipeline.with_limits(limits);
 		self
 	}


### PR DESCRIPTION
The general idea is to be able to define extra limit fields per platform.
Example of an extension is provided for the Optimism platform to add data availability limits.

For this:
- extensions should implement `LimitExtension` and defined with new associated type `ExtraLimits` at platform level
- no extension can be defined with ()
- `Limits` is bounded by `Platform` generic ("limits *of* a platform")
- PlatformExecBounds is updated to have access to specific limit extension within pipeline steps
