### PR TITLE
feat: make Platform::next_block_environment_context faillible 

### DIFF
--- a/examples/custom-platform.rs
+++ b/examples/custom-platform.rs
@@ -47,7 +47,8 @@ impl Platform for CustomPlatform {
 		chainspec: &types::ChainSpec<Optimism>,
 		parent: &types::Header<Optimism>,
 		attributes: &types::PayloadBuilderAttributes<Optimism>,
-	) -> types::NextBlockEnvContext<Optimism> {
+	) -> Result<types::NextBlockEnvContext<Optimism>, types::EvmEnvError<Optimism>>
+	{
 		Optimism::next_block_environment_context::<Self>(
 			chainspec, parent, attributes,
 		)

--- a/src/payload/block.rs
+++ b/src/payload/block.rs
@@ -75,7 +75,8 @@ impl<P: Platform> BlockContext<P> {
 			&chainspec,
 			parent.header(),
 			&attribs,
-		);
+		)
+		.map_err(Error::EvmEnv)?;
 
 		let evm_config = P::evm_config::<P>(Arc::clone(&chainspec));
 		let evm_env = evm_config

--- a/src/platform/ethereum/mod.rs
+++ b/src/platform/ethereum/mod.rs
@@ -77,19 +77,22 @@ impl Platform for Ethereum {
 		EthEvmConfig::new(chainspec)
 	}
 
+	/// Prepares a block environment containing all the information needed to
+	/// build a new block. This is infallible for Ethereum and can be safely
+	/// unwrapped.
 	fn next_block_environment_context<P>(
 		_: &types::ChainSpec<Self>,
 		parent: &types::Header<Self>,
 		attributes: &types::PayloadBuilderAttributes<Self>,
-	) -> types::NextBlockEnvContext<Self> {
-		NextBlockEnvAttributes {
+	) -> Result<types::NextBlockEnvContext<Self>, types::EvmEnvError<Self>> {
+		Ok(NextBlockEnvAttributes {
 			timestamp: attributes.timestamp,
 			suggested_fee_recipient: attributes.suggested_fee_recipient,
 			prev_randao: attributes.prev_randao,
 			gas_limit: EthereumBuilderConfig::new().gas_limit(parent.gas_limit()),
 			parent_beacon_block_root: attributes.parent_beacon_block_root,
 			withdrawals: Some(attributes.withdrawals.clone()),
-		}
+		})
 	}
 
 	fn build_payload<P>(

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -103,7 +103,7 @@ pub trait Platform:
 		chainspec: &types::ChainSpec<P>,
 		parent: &types::Header<P>,
 		attributes: &types::PayloadBuilderAttributes<P>,
-	) -> types::NextBlockEnvContext<P>
+	) -> Result<types::NextBlockEnvContext<P>, types::EvmEnvError<P>>
 	where
 		P: traits::PlatformExecBounds<Self>;
 


### PR DESCRIPTION
`next_block_environment_context` is infaillible for Ethereum, but not for Optimism or other platforms.
We need to handle errors instead of using `unwrap_or_default` (for example: when fees are misconfigured)

Also added extra data for jovian