### PR TITLE
chore: add reth and alloy re-exports

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,7 @@ optimism = [
     "reth-node-builder/op",
     "reth-payload-util",
     "reth-optimism-cli",
+    "reth-optimism-rpc",
     "rblib-tests-macros?/optimism",
 ]
 
@@ -119,12 +120,15 @@ alloy-origin = { version = "1.0.41", package = "alloy", features = [
     "rpc-types-mev",
 ] }
 alloy-evm = "0.23.0"
+alloy-json-rpc = "1.0.41"
+alloy-serde = "1.0.41"
 
 # Reth dependencies
 reth-origin = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", package = "reth" }
 reth-evm = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-errors = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-cli = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
+reth-db-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-rpc-api = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-basic-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-ethereum-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
@@ -132,6 +136,7 @@ reth-ethereum = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3", f
     "node",
     "evm",
 ] }
+reth-network-peers = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-transaction-pool = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-payload-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }
 reth-node-builder = { git = "https://github.com/paradigmxyz/reth", tag = "v1.9.3" }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,10 @@ pub mod reth {
 		pub use reth_ethereum::*;
 	}
 
+	pub mod network_peers {
+		pub use reth_network_peers::*;
+	}
+
 	#[cfg(feature = "optimism")]
 	pub mod optimism {
 		pub mod chainspec {
@@ -86,6 +90,9 @@ pub mod reth {
 		}
 		pub mod node {
 			pub use reth_optimism_node::*;
+		}
+		pub mod rpc {
+			pub use reth_optimism_rpc::*;
 		}
 		pub mod forks {
 			pub use reth_optimism_forks::*;
@@ -104,6 +111,10 @@ pub mod alloy {
 
 	pub mod evm {
 		pub use alloy_evm::*;
+	}
+
+	pub mod serde {
+		pub use alloy_serde::*;
 	}
 
 	#[cfg(any(test, feature = "test-utils"))]


### PR DESCRIPTION
So unichain-builder doesn't need to import different reth crates