### PR TITLE
fix: modify Platform trait

### DIFF
--- a/examples/custom-platform.rs
+++ b/examples/custom-platform.rs
@@ -60,7 +60,7 @@ impl Platform for CustomPlatform {
 		provider: &dyn StateProvider,
 	) -> Result<types::BuiltPayload<Self>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecBounds<Self>,
+		P: traits::PlatformExecCtxBounds<Self>,
 	{
 		Optimism::build_payload::<P>(payload, provider)
 	}

--- a/src/pipelines/mod.rs
+++ b/src/pipelines/mod.rs
@@ -434,6 +434,19 @@ pub mod traits {
 			>
 	{
 	}
+
+	// equal to `PlatformExecBounds` but with stricter checkpoint context
+	pub trait PlatformExecCtxBounds<P: Platform>:
+		PlatformExecBounds<P>
+		+ Platform<CheckpointContext = types::CheckpointContext<P>>
+	{
+	}
+
+	impl<T: Platform, P: Platform> PlatformExecCtxBounds<T> for P where
+		P: PlatformExecBounds<T>
+			+ Platform<CheckpointContext = types::CheckpointContext<T>>
+	{
+	}
 }
 
 // internal utilities

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -122,7 +122,7 @@ pub trait Platform:
 		provider: &dyn StateProvider,
 	) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecBounds<Self>;
+		P: traits::PlatformExecCtxBounds<Self>;
 }
 
 /// This is an optional extension trait for platforms that want to provide info

--- a/src/platform/optimism/mod.rs
+++ b/src/platform/optimism/mod.rs
@@ -93,7 +93,7 @@ impl Platform for Optimism {
 		provider: &dyn StateProvider,
 	) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecBounds<Self>,
+		P: traits::PlatformExecCtxBounds<Self>,
 	{
 		let block = payload.block();
 		let transactions = extract_external_txs(&payload);

--- a/src/platform/types.rs
+++ b/src/platform/types.rs
@@ -103,6 +103,9 @@ pub type DefaultLimits<P: Platform> = P::DefaultLimits;
 /// Extracts the type that can provide additional limits.
 pub type ExtraLimits<P: Platform> = P::ExtraLimits;
 
+/// Extracts the type that contains the checkpoint context.
+pub type CheckpointContext<P: Platform> = P::CheckpointContext;
+
 /// The result of executing a transaction in the EVM.
 pub type TransactionExecutionResult<P: Platform> =
 	ExecutionResult<EvmHaltReason<P>>;


### PR DESCRIPTION
This PR makes it possible to actually return the Platform specific context in the `build_payload` fn of the `Platform` trait.

This way you can use the platform specific context there to do what you need. Otherwise you get a generic `P::CheckpointContext` type that you cannot really use.

Before this PR:

```rust
fn build_payload<P>(
    payload: Checkpoint<P>,
    provider: &dyn StateProvider,
    ) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
    where
    P: PlatformExecBounds<Self>,
    {
        // here is just the generic P::CheckpointContext
        let my_context = payload.context();
        ...
}
```

With this PR:

```rust
fn build_payload<P>(
    payload: Checkpoint<P>,
    provider: &dyn StateProvider,
    ) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
    where
    P: PlatformExecCtxBounds<Self>,
    {
        // here is the very specific type, and you access all its inner elements
        let my_context = payload.context();
        ...
}
```