### PR TITLE
feat: add latest_barrier method to CheckpointExt trait

### DIFF
--- a/src/payload/ext/checkpoint.rs
+++ b/src/payload/ext/checkpoint.rs
@@ -169,10 +169,7 @@ pub trait CheckpointExt<P: Platform>: super::sealed::Sealed {
 	/// Returns the latest barrier checkpoint in the history of this checkpoint,
 	/// if any.
 	fn latest_barrier(&self) -> Option<Checkpoint<P>> {
-		let history = self.history();
-		let index = history.iter().rposition(Checkpoint::is_barrier)?;
-		let barrier_checkpoint = history.at(index)?.clone();
-		Some(barrier_checkpoint)
+		self.history().iter().rfind(|cp| cp.is_barrier()).cloned()
 	}
 }
 


### PR DESCRIPTION
This PR adds the `latest_barrier` method to the `CheckpointExt` trait with a default implementation.

This is an helper method that returns the latest barrier checkpoint in the history of this checkpoint, if any. It returns `None` if no barrier checkpoint is found in the history.