### PR TITLE
chore: fix clippy lints on rust 1.92

### DIFF
--- a/src/test_utils/mod.rs
+++ b/src/test_utils/mod.rs
@@ -22,8 +22,8 @@ mod platform;
 mod step;
 mod transactions;
 
-pub(crate) use step::fake_step;
 pub use {
+	crate::fake_step,
 	accounts::{FundedAccounts, WithFundedAccounts},
 	ethereum::EthConsensusDriver,
 	exts::*,

--- a/src/test_utils/step.rs
+++ b/src/test_utils/step.rs
@@ -16,6 +16,7 @@ use {
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct StringEvent(pub String);
 
+#[macro_export]
 macro_rules! fake_step {
 	($name:ident) => {
 		#[allow(unreachable_pub)]
@@ -147,8 +148,6 @@ macro_rules! fake_step {
 		}
 	};
 }
-
-pub(crate) use fake_step;
 
 fake_step!(AlwaysOkStep, noop_ok);
 fake_step!(AlwaysBreakStep, noop_break);


### PR DESCRIPTION
CI fails on latest stable (1.92) - https://github.com/flashbots/rblib/actions/runs/20131630915/job/57811631504

This minor change fixes the re-exports and removes the clippy error.