### PR TITLE
fix: loosen bounds on CheckpointContext so we can override it

### DIFF
--- a/examples/custom-platform.rs
+++ b/examples/custom-platform.rs
@@ -59,7 +59,7 @@ impl Platform for CustomPlatform {
 		provider_factory: types::ProviderFactory<P>,
 	) -> Result<types::BuiltPayload<Self>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecCtxBounds<Self>,
+		P: traits::PlatformExecBounds<Self>,
 	{
 		Optimism::build_payload::<P>(payload, provider_factory)
 	}

--- a/src/platform/mod.rs
+++ b/src/platform/mod.rs
@@ -127,7 +127,7 @@ pub trait Platform:
 		provider_factory: types::ProviderFactory<P>,
 	) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecCtxBounds<Self>;
+		P: traits::PlatformExecBounds<Self>;
 }
 
 /// This is an optional extension trait for platforms that want to provide info

--- a/src/platform/optimism/mod.rs
+++ b/src/platform/optimism/mod.rs
@@ -92,7 +92,7 @@ impl Platform for Optimism {
 		provider_factory: types::ProviderFactory<P>,
 	) -> Result<types::BuiltPayload<P>, PayloadBuilderError>
 	where
-		P: traits::PlatformExecCtxBounds<Self>,
+		P: traits::PlatformExecBounds<Self>,
 	{
 		let block = payload.block();
 		let transactions = extract_external_txs(&payload);


### PR DESCRIPTION
The restriction introduced in https://github.com/flashbots/rblib/pull/97 meant that we can't define our own custom checkpoint context when using the optimism platform functions.

See https://github.com/flashbots/unichain-builder/pull/55