### PR TITLE
Prepare v0.4.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ members = [
 resolver = "2"
 
 [workspace.package]
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 rust-version = "1.91"
 license = "MIT"


### PR DESCRIPTION
This bump rblib version to `v0.4.2` version intended to be released before migrating to a workspace in #106
